### PR TITLE
ramips/mtwifi: disable bind apcli interface to lan by default

### DIFF
--- a/package/lean/mt/luci-app-mtwifi/Makefile
+++ b/package/lean/mt/luci-app-mtwifi/Makefile
@@ -7,7 +7,7 @@ LUCI_TITLE:=LuCI support for mt wifi driver
 LUCI_DEPENDS:=@TARGET_ramips +mt_wifi
 LUCI_PKGARCH:=all
 PKG_VERSION:=1
-PKG_RELEASE:=15
+PKG_RELEASE:=16
 
 define Package/luci-app-mtwifi/conffiles
 /etc/wireless/mt7615/

--- a/package/lean/mt/luci-app-mtwifi/luasrc/controller/mtkwifi.lua
+++ b/package/lean/mt/luci-app-mtwifi/luasrc/controller/mtkwifi.lua
@@ -769,14 +769,14 @@ function apcli_connect(dev, vif)
     mtkwifi.save_profile(cfgs, profiles[devname])
 
     os.execute("ifconfig "..vifname.." up")
-    local brvifs = mtkwifi.__trim(mtkwifi.read_pipe("uci get network.lan.ifname"))
-    if not string.match(brvifs, vifname) then
-        brvifs = brvifs.." "..vifname
-        nixio.syslog("debug", "add "..vifname.." into lan")
-        os.execute("uci set network.lan.ifname=\""..brvifs.."\"")
-        os.execute("uci commit")
-        os.execute("ubus call network.interface.lan add_device \"{\\\"name\\\":\\\""..vifname.."\\\"}\"")
-    end
+--    local brvifs = mtkwifi.__trim(mtkwifi.read_pipe("uci get network.lan.ifname"))
+--    if not string.match(brvifs, vifname) then
+--        brvifs = brvifs.." "..vifname
+--        nixio.syslog("debug", "add "..vifname.." into lan")
+--        os.execute("uci set network.lan.ifname=\""..brvifs.."\"")
+--        os.execute("uci commit")
+--        os.execute("ubus call network.interface.lan add_device \"{\\\"name\\\":\\\""..vifname.."\\\"}\"")
+--    end
 
     os.execute("iwpriv "..vifname.." set MACRepeaterEn="..cfgs.MACRepeaterEn)
     os.execute("iwpriv "..vifname.." set ApCliEnable=0")
@@ -815,14 +815,14 @@ function apcli_disconnect(dev, vif)
 
     os.execute("iwpriv "..vifname.." set ApCliEnable=0")
 
-    local brvifs = mtkwifi.__trim(mtkwifi.read_pipe("uci get network.lan.ifname"))
-    if string.match(brvifs, vifname) then
-        brvifs = mtkwifi.__trim(string.gsub(brvifs, vifname, ""))
-        nixio.syslog("debug", "add "..vifname.." into lan")
-        os.execute("uci set network.lan.ifname=\""..brvifs.."\"")
-        os.execute("uci commit")
-        os.execute("ubus call network.interface.lan remove_device \"{\\\"name\\\":\\\""..vifname.."\\\"}\"")
-    end
+--    local brvifs = mtkwifi.__trim(mtkwifi.read_pipe("uci get network.lan.ifname"))
+--    if string.match(brvifs, vifname) then
+--        brvifs = mtkwifi.__trim(string.gsub(brvifs, vifname, ""))
+--        nixio.syslog("debug", "add "..vifname.." into lan")
+--        os.execute("uci set network.lan.ifname=\""..brvifs.."\"")
+--        os.execute("uci commit")
+--        os.execute("ubus call network.interface.lan remove_device \"{\\\"name\\\":\\\""..vifname.."\\\"}\"")
+--    end
     os.execute("ifconfig "..vifname.." down")
 
     luci.http.redirect(luci.dispatcher.build_url("admin", "network", "wifi"))

--- a/package/lean/mt/luci-app-mtwifi/luasrc/view/admin_mtk/mtk_wifi_overview.htm
+++ b/package/lean/mt/luci-app-mtwifi/luasrc/view/admin_mtk/mtk_wifi_overview.htm
@@ -81,8 +81,10 @@ local devs = mtkwifi.get_all_devs()
                         <input class="cbi-button cbi-button-apply" style="width:100px" title="禁用无线" value="启用" type="button" onclick="location.href='<%=luci.dispatcher.build_url("admin", "network", "wifi", "vif_enable", vif.vifname)%>'" />
                         <% end %>
                         <input class="cbi-button cbi-button-edit" style="width:100px" title="修改无线基本设置" value="基本设置" type="button" onclick="location.href='<%=luci.dispatcher.build_url("admin", "network", "wifi", "vif_cfg_view", dev.devname, vif.vifname)%>'" />
-                        <% if dev.apcli.state == "down" then %>
-                        <input class="cbi-button cbi-button-apply" style="width:100px" title="启用无线" value="启用中继" type="button" onclick="location.href='<%=luci.dispatcher.build_url("admin", "network", "wifi", "vif_enable", dev.apcli.vifname)%>'" />
+                        <% if dev.apcli then %>
+                            <% if dev.apcli.state == "down" then %>
+                            <input class="cbi-button cbi-button-apply" style="width:100px" title="启用无线" value="启用中继" type="button" onclick="location.href='<%=luci.dispatcher.build_url("admin", "network", "wifi", "vif_enable", dev.apcli.vifname)%>'" />
+                            <% end %>
                         <% end %>
                         <input class="cbi-button cbi-button-remove" style="width:100px" title="删除网络" value="移除" type="button" onclick="location.href='<%=luci.dispatcher.build_url("admin", "network", "wifi", "vif_del", dev.devname, vif.vifname)%>'" />
                     </td>

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
@@ -15,7 +15,6 @@ ramips_setup_interfaces()
 	asiarf,ap7621-nv1|\
 	lenovo,newifi-d1|\
 	mikrotik,routerboard-m33g|\
-	xiaomi,mir3g|\
 	xiaomi,mir3g-v2|\
 	xiaomi,mir4)
 		ucidef_set_interfaces_lan_wan "lan1 lan2" "wan"
@@ -23,7 +22,7 @@ ramips_setup_interfaces()
 	d-team,newifi-d2)
 		ucidef_add_switch "switch0" \
 			"0:lan:4" "1:lan:3" "2:lan:2" "3:lan:1" "4:wan:5" "6@eth0"
-		ucidef_set_interface_lan "eth0.1 ra0 rai0 apcli0 apclii0"
+		ucidef_set_interface_lan "eth0.1 ra0 rai0"
 		;;
 	hiwifi,hc5962|\
 	xiaomi,mir3p)
@@ -32,7 +31,7 @@ ramips_setup_interfaces()
 	gehua,ghl-r-001)
 		ucidef_add_switch "switch0" \
 			"0:lan" "1:lan" "2:lan" "4:wan" "6@eth0"
-		ucidef_set_interface_lan "eth0.1 ra0 rai0 apcli0 apclii0"
+		ucidef_set_interface_lan "eth0.1 ra0 rai0"
 		;;
 	gnubee,gb-pc1|\
 	gnubee,gb-pc2)
@@ -63,7 +62,7 @@ ramips_setup_interfaces()
 	phicomm,k2p)
 		ucidef_add_switch "switch0" \
 			"0:lan" "1:lan" "2:lan" "3:lan" "4:wan" "6@eth0"
-		ucidef_set_interface_lan "eth0.1 ra0 rax0 apcli0 apclix0"
+		ucidef_set_interface_lan "eth0.1 ra0 rax0"
 		;;
 	ubnt,edgerouter-x)
 		ucidef_set_interface_lan_wan "eth1 eth2 eth3 eth4" "eth0"
@@ -79,7 +78,7 @@ ramips_setup_interfaces()
 	xiaomi,redmi-router-ac2100)
 		ucidef_add_switch "switch0" \
 			"0:wan" "2:lan:1" "3:lan:2" "4:lan:3" "6@eth0"
-		ucidef_set_interface_lan "eth0.2 ra0 rai0 apcli0 apclii0"
+		ucidef_set_interface_lan "eth0.2 ra0 rai0"
 		;;
 	*)
 		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4" "wan"


### PR DESCRIPTION
The apcli interface can be bound to either lan or wan.

Q：你知道这是`pull request`吗？(使用 "x" 选择)
* [ ] 我知道
